### PR TITLE
 Allow MAPS section to be defined by the environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -y && apt-get install -y netcat git nodejs npm php5-curl && a
     php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
     php composer-setup.php --install-dir=/usr/bin && \
     php -r "unlink('composer-setup.php');" && \
-    git clone https://gitlab.com/counterstrafe/ebot-csgo.git "$EBOT_HOME" && \
+    git clone https://github.com/deStrO/eBot-CSGO.git "$EBOT_HOME" && \
     cd "$EBOT_HOME" && git checkout "master" && \
     /usr/local/bin/php /usr/bin/composer.phar install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,9 @@ RUN apt-get update -y && apt-get install -y netcat git nodejs npm php5-curl && a
     php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
     php composer-setup.php --install-dir=/usr/bin && \
     php -r "unlink('composer-setup.php');" && \
-    git clone https://github.com/deStrO/eBot-CSGO.git "$EBOT_HOME" && \
+    git clone https://gitlab.com/counterstrafe/ebot-csgo.git "$EBOT_HOME" && \
     cd "$EBOT_HOME" && git checkout "master" && \
-    /usr/local/bin/php /usr/bin/composer.phar install && \
-    cp "$EBOT_HOME"/config/config.ini.smp "$EBOT_HOME"/config/config.ini
+    /usr/local/bin/php /usr/bin/composer.phar install
 
 WORKDIR ${EBOT_HOME}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,27 +19,52 @@ USE_DELAY_END_RECORD="${USE_DELAY_END_RECORD:-true}"
 
 TOORNAMENT_PLUGIN_KEY="${TOORNAMENT_PLUGIN_KEY:-azertylol}"
 
+MAPS="${MAPS:-de_dust2,de_mirage}"
+# Split string by comma into an array
+IFS=',' read -ra map_array <<< "$MAPS"
+
+CONFIG_FILE="$EBOT_HOME/config/config.ini"
+CONFIG_FILE_SAMPLE="$CONFIG_FILE.smp"
+CONFIG_FILE_TMP="$CONFIG_FILE.tmp"
+
+# Remove sample maps
+cat $CONFIG_FILE_SAMPLE | grep -v 'MAP\[\] = "' > $CONFIG_FILE_TMP
+
+# Write config.ini file with configured maps
+while read line; do
+	if [[ "$line" =~ "[MAPS]" ]]; then
+		echo $line >> $CONFIG_FILE
+		for map in "${map_array[@]}"
+		do
+			echo "MAP[] = \"$map\"" >> $CONFIG_FILE
+		done
+	else
+		echo $line >> $CONFIG_FILE
+	fi
+done < $CONFIG_FILE_TMP
+
+rm $CONFIG_FILE_TMP
+
 # for usage with docker-compose
 while ! nc -z $MYSQL_HOST $MYSQL_PORT; do sleep 3; done
 
 echo 'date.timezone = "${TIMEZONE}"' >> /usr/local/etc/php/conf.d/php.ini
 
-sed -i "s/BOT_IP =.*/BOT_IP = \"$CONTAINER_IP\"/g" $EBOT_HOME/config/config.ini
-#sed -i "s/BOT_IP =.*/BOT_IP = \"$EXTERNAL_IP\"/g" $EBOT_HOME/config/config.ini
-sed -i "s/EXTERNAL_LOG_IP = .*/EXTERNAL_LOG_IP = \"$EXTERNAL_IP\"/g" $EBOT_HOME/config/config.ini
-sed -i "s/MYSQL_IP =.*/MYSQL_IP = \"$MYSQL_HOST\"/g" $EBOT_HOME/config/config.ini
-sed -i "s/MYSQL_PORT =.*/MYSQL_PORT = \"$MYSQL_PORT\"/g" $EBOT_HOME/config/config.ini
-sed -i "s/MYSQL_USER =.*/MYSQL_USER = \"$MYSQL_USER\"/g" $EBOT_HOME/config/config.ini
-sed -i "s/MYSQL_PASS =.*/MYSQL_PASS = \"$MYSQL_PASS\"/g" $EBOT_HOME/config/config.ini
-sed -i "s/MYSQL_BASE =.*/MYSQL_BASE = \"$MYSQL_DB\"/g" $EBOT_HOME/config/config.ini
-sed -i "s/LO3_METHOD =.*/LO3_METHOD = \"$LO3_METHOD\"/g" $EBOT_HOME/config/config.ini
-sed -i "s/KO3_METHOD =.*/KO3_METHOD = \"$KO3_METHOD\"/g" $EBOT_HOME/config/config.ini
-sed -i "s/DEMO_DOWNLOAD =.*/DEMO_DOWNLOAD = $DEMO_DOWNLOAD/g" $EBOT_HOME/config/config.ini
-sed -i "s/REMIND_RECORD =.*/REMIND_RECORD = $REMIND_RECORD/g" $EBOT_HOME/config/config.ini
-sed -i "s/DAMAGE_REPORT =.*/DAMAGE_REPORT = $DAMAGE_REPORT/g" $EBOT_HOME/config/config.ini
-sed -i "s/DAMAGE_REPORT =.*/DAMAGE_REPORT = $DAMAGE_REPORT/g" $EBOT_HOME/config/config.ini
-sed -i "s/DELAY_READY = .*/DELAY_READY = $DELAY_READY/g" $EBOT_HOME/config/config.ini
-sed -i "s/USE_DELAY_END_RECORD = .*/USE_DELAY_END_RECORD = \"$USE_DELAY_END_RECORD\"/g" $EBOT_HOME/config/config.ini
+sed -i "s/BOT_IP =.*/BOT_IP = \"$CONTAINER_IP\"/g" $CONFIG_FILE
+sed -i "s/EXTERNAL_LOG_IP = .*/EXTERNAL_LOG_IP = \"$EXTERNAL_IP\"/g" $CONFIG_FILE
+sed -i "s/MYSQL_IP =.*/MYSQL_IP = \"$MYSQL_HOST\"/g" $CONFIG_FILE
+sed -i "s/MYSQL_PORT =.*/MYSQL_PORT = \"$MYSQL_PORT\"/g" $CONFIG_FILE
+sed -i "s/MYSQL_USER =.*/MYSQL_USER = \"$MYSQL_USER\"/g" $CONFIG_FILE
+sed -i "s/MYSQL_PASS =.*/MYSQL_PASS = \"$MYSQL_PASS\"/g" $CONFIG_FILE
+sed -i "s/MYSQL_BASE =.*/MYSQL_BASE = \"$MYSQL_DB\"/g" $CONFIG_FILE
+sed -i "s/LO3_METHOD =.*/LO3_METHOD = \"$LO3_METHOD\"/g" $CONFIG_FILE
+sed -i "s/KO3_METHOD =.*/KO3_METHOD = \"$KO3_METHOD\"/g" $CONFIG_FILE
+sed -i "s/DEMO_DOWNLOAD =.*/DEMO_DOWNLOAD = $DEMO_DOWNLOAD/g" $CONFIG_FILE
+sed -i "s/REMIND_RECORD =.*/REMIND_RECORD = $REMIND_RECORD/g" $CONFIG_FILE
+sed -i "s/DAMAGE_REPORT =.*/DAMAGE_REPORT = $DAMAGE_REPORT/g" $CONFIG_FILE
+sed -i "s/DAMAGE_REPORT =.*/DAMAGE_REPORT = $DAMAGE_REPORT/g" $CONFIG_FILE
+sed -i "s/DELAY_READY = .*/DELAY_READY = $DELAY_READY/g" $CONFIG_FILE
+sed -i "s/USE_DELAY_END_RECORD = .*/USE_DELAY_END_RECORD = \"$USE_DELAY_END_RECORD\"/g" $CONFIG_FILE
 
 echo -e "\n" >> $EBOT_HOME/config/plugins.ini
 echo '[\eBot\Plugins\Official\ToornamentNotifier]' >> $EBOT_HOME/config/plugins.ini

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ USE_DELAY_END_RECORD="${USE_DELAY_END_RECORD:-true}"
 
 TOORNAMENT_PLUGIN_KEY="${TOORNAMENT_PLUGIN_KEY:-azertylol}"
 
-MAPS="${MAPS:-de_dust2,de_mirage}"
+MAPS="${MAPS:-de_dust2_se,de_nuke_se,de_inferno_se,de_mirage_ce,de_train_se,de_cache,de_season,de_dust2,de_nuke,de_inferno,de_train,de_mirage,de_cbble,de_overpass}"
 # Split string by comma into an array
 IFS=',' read -ra map_array <<< "$MAPS"
 


### PR DESCRIPTION
Have entrypoint.sh be responsible for creating config.ini and allow maps definied by the environment.

Now we can define maps here: https://gitlab.com/counterstrafe/docker-ebot/blob/master/docker-compose.yml#L14-29
and have them get generated here: https://gitlab.com/counterstrafe/ebot-csgo/blob/master/config/config.ini.smp#L35-49