### PR TITLE
Build instead of using images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ebot:
-  image: hsfactory/ebot
+  build: https://github.com/jffz/docker-ebot.git
   restart: always
   links:
     - "mysql:mysql"
@@ -29,7 +29,7 @@ ebot:
     TOORNAMENT_PLUGIN_KEY: ''
 
 ebotweb:
-  image: hsfactory/ebotweb
+  build: https://github.com/jffz/docker-ebotweb.git
   restart: always
   links:
     - "mysql:mysql"


### PR DESCRIPTION
The images on docker isn't really up-to date, and not having the latest ebot changes.
Might be me that's just a noob. But spent way too long finding a solution that worked for me.
This is just a proposed solution. There should maybe be a image and build options. But i haven't mastered docker-compose enough to do this. 

Or maybe we can setup a auto-build on dockerhub, for when the original ebot github gets an update.